### PR TITLE
Add immersive fancy card with animations

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import {
   useTheme,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import FancyCard from './FancyCard';
 import { MusicNote, Pause, Refresh, Error as ErrorIcon } from '@mui/icons-material';
 
 // 自定义样式组件
@@ -260,6 +261,12 @@ function App() {
         </Box>
       </Container>
 
+      <Container sx={{ py: 4 }}>
+        <Box sx={{ maxWidth: 500, mx: 'auto' }}>
+          <FancyCard />
+        </Box>
+      </Container>
+
       {/* 页脚 */}
       <Box
         component="footer"
@@ -322,6 +329,11 @@ function App() {
         @keyframes float {
           0%, 100% { transform: translateY(0px) rotate(0deg); }
           50% { transform: translateY(-20px) rotate(180deg); }
+        }
+
+        @keyframes spin {
+          from { transform: rotate(0deg); }
+          to { transform: rotate(360deg); }
         }
       `}</style>
     </Box>

--- a/src/FancyCard.js
+++ b/src/FancyCard.js
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { Box, Typography } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+const CardRoot = styled(Box)(({ theme }) => ({
+  position: 'relative',
+  overflow: 'hidden',
+  borderRadius: theme.shape.borderRadius * 2,
+  padding: theme.spacing(4),
+  background: theme.palette.background.paper,
+  boxShadow: theme.shadows[4],
+  transformStyle: 'preserve-3d',
+  transition: theme.transitions.create(['transform', 'box-shadow'], {
+    duration: theme.transitions.duration.standard,
+  }),
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    inset: -2,
+    background: `conic-gradient(${theme.palette.primary.main}, ${theme.palette.primary.light}, ${theme.palette.primary.main})`,
+    filter: 'blur(8px)',
+    animation: 'spin 6s linear infinite',
+    zIndex: -1,
+  },
+  '&:hover': {
+    boxShadow: theme.shadows[12],
+  },
+}));
+
+function FancyCard({ children }) {
+  const [style, setStyle] = useState({});
+
+  const handleMove = (event) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const x = event.clientX - rect.left - rect.width / 2;
+    const y = event.clientY - rect.top - rect.height / 2;
+    setStyle({
+      transform: `rotateX(${(-y / rect.height) * 10}deg) rotateY(${(x / rect.width) * 10}deg)`,
+    });
+  };
+
+  const handleLeave = () => setStyle({ transform: 'rotateX(0deg) rotateY(0deg)' });
+
+  return (
+    <CardRoot onMouseMove={handleMove} onMouseLeave={handleLeave} sx={style}>
+      <Typography variant="h6" gutterBottom>
+        沉浸式卡片
+      </Typography>
+      <Typography color="text.secondary">
+        {children || '尝试移动鼠标，感受立体效果'}
+      </Typography>
+    </CardRoot>
+  );
+}
+
+export default FancyCard;


### PR DESCRIPTION
## Summary
- create `FancyCard` component with 3D hover effect and animated gradient halo
- display the new card in the main page
- define global `spin` keyframes for the card animation

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*